### PR TITLE
Fix constructing search ui url and remove setup-python from usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ jobs:
     name: Get Thoth recommenations on your dependencies
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
       - name: Get Thoth security advisories
         id: thoth-advise
         uses: thoth-station/thoth-github-action@v1

--- a/action.yaml
+++ b/action.yaml
@@ -27,7 +27,7 @@ runs:
         sed -i "s/pip-tools/${{ inputs.requirements-format }}/g" $GITHUB_ACTION_PATH/actions/ubuntu_config_template.yaml
         thamos config --no-interactive --template $GITHUB_ACTION_PATH/actions/ubuntu_config_template.yaml
         thamos advise --recommendation-type security > advise_result.json
-        echo "::set-output name=thoth-search-ui-link::'https://thoth-station.ninja/search/$(cat .thoth_last_analysis_id)/summary'"
+        echo "::set-output name=thoth-search-ui-link::https://thoth-station.ninja/search/$(cat .thoth_last_analysis_id)/summary"
         echo "::set-output name=advise-result::$(cat advise_result.json)"
     - name: Comment Pull Request
       uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
## This introduces a breaking change

- No

## This Pull Request implements

- Remove setup-python from usage example in README as it is a duplicate action and causes issues with glibc version required for the Python version setup with the action vs. the Python version present in s2i-thoth image
- Fix URL to Search UI
