### PR TITLE
Make pipenv default and inputs required

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -4,9 +4,12 @@ description: Get Security Recommendations on your Python Dependencies
 inputs:
   requirements-path:
     description: Dependency requirements file path
+    required: true
     default: Pipfile
   requirements-format:
     description: Requirements format for dependencies, one of (pip | pip-tools | pip-compile | pipenv)
+    required: true
+    default: pipenv
 outputs:
   thoth-search-ui-link:
     description: Link to results in Thoth Search UI
@@ -28,7 +31,7 @@ runs:
         mkdir /tmp/thoth/
         cp -r * /tmp/thoth/
         cd /tmp/thoth/
-        sed -i "s/pip-tools/${{ inputs.requirements-format }}/g" $GITHUB_ACTION_PATH/actions/ubuntu_config_template.yaml
+        sed -i "s/pipenv/${{ inputs.requirements-format }}/g" $GITHUB_ACTION_PATH/actions/ubuntu_config_template.yaml
         thamos config --no-interactive --template $GITHUB_ACTION_PATH/actions/ubuntu_config_template.yaml
         thamos advise --recommendation-type security --no-write --json > $GITHUB_ACTION_PATH/advise_result.json
         if [[ $? -eq 0 ]];

--- a/actions/ubuntu_config_template.yaml
+++ b/actions/ubuntu_config_template.yaml
@@ -1,6 +1,6 @@
 host: khemenu.thoth-station.ninja
 tls_verify: true
-requirements_format: pip-tools
+requirements_format: pipenv
 
 runtime_environments:
   - name: ubi8


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/thoth-github-action/issues/23
For the moment, make users specify both requirements path and requirements format.

## This introduces a breaking change

- No
