### PR TITLE
Fix empty optional input parameter

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -46,7 +46,7 @@ runs:
         else
             requirements_format=${{ inputs.requirements-format }}
         fi
-        if [ ${{ inputs.overlay-directory }} != '' ];
+        if [ '${{ inputs.overlay-directory }}' != '' ];
             then
             thamos check
             sed -i "s/pipenv/$requirements_format/g" .thoth.yaml


### PR DESCRIPTION
## This introduces a breaking change

- No

## This Pull Request implements

Make optional `overlay-directory` parameter an empty string when not specified by user.
